### PR TITLE
Fix auth bootstrap flicker and first-login redirect race

### DIFF
--- a/src/app/__root.tsx
+++ b/src/app/__root.tsx
@@ -6,11 +6,11 @@ import {
 } from "@tanstack/react-router";
 import { Toaster } from "@/components/ui/toaster";
 import React from "react";
-import { useConvexAuth } from "convex/react";
 import { ClientSet } from "@/lib/queryClient";
+import { PersistUserAuth } from "@/hooks/use-persist-user";
 
 export const Route = createRootRouteWithContext<{
-  auth: ReturnType<typeof useConvexAuth>;
+  auth: PersistUserAuth;
   clients: ClientSet;
 }>()({
   head: () => ({

--- a/src/app/_authenticated/route.tsx
+++ b/src/app/_authenticated/route.tsx
@@ -1,58 +1,25 @@
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
-import React from "react";
-import { usePersistUserEffect } from "@/hooks/use-persist-user";
 import { Header } from "@/components/Header";
 import Footer from "@/components/Footer";
-import { Loader2 } from "lucide-react";
 
 export const Route = createFileRoute("/_authenticated")({
-  component: RouteComponent,
+  component: AuthenticatedLayout,
   beforeLoad: async ({ context }) => {
-    if (!context.auth.isAuthenticated) {
+    if (context.auth.status === "signedOut") {
       redirect({ to: "/", replace: true, throw: true });
     }
   },
 });
 
-function RouteComponent() {
-  return (
-    <AuthenticatedLayout>
-      <Outlet />
-    </AuthenticatedLayout>
-  );
-}
-
-function AuthenticatedLayoutInnerPersistor({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const { isLoading, isAuthenticated } = usePersistUserEffect();
-
-  if (isLoading || !isAuthenticated) {
-    return (
-      <div className="relative container mx-auto flex grow flex-col items-center p-12">
-        <Loader2 className="h-10 w-10 animate-spin text-primary" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="container relative  mx-auto flex grow flex-col">
-      {children}
-    </div>
-  );
-}
-
-function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
+function AuthenticatedLayout() {
   return (
     <div className="flex flex-col">
       <div className="flex min-h-screen flex-col">
         <Header />
 
-        <AuthenticatedLayoutInnerPersistor>
-          {children}
-        </AuthenticatedLayoutInnerPersistor>
+        <div className="container relative  mx-auto flex grow flex-col">
+          <Outlet />
+        </div>
 
         <Footer />
       </div>

--- a/src/app/_public/index.tsx
+++ b/src/app/_public/index.tsx
@@ -29,7 +29,7 @@ import { PublicLayout } from "@/components/PublicLayout";
 export const Route = createFileRoute("/_public/")({
   component: PublicHome,
   beforeLoad: async ({ context }) => {
-    if (context.auth.isAuthenticated) {
+    if (context.auth.status === "ready") {
       redirect({ to: "/dashboard", replace: true, throw: true });
     }
   },
@@ -67,7 +67,7 @@ function PublicHome() {
             </p>
 
             <div className="flex flex-col items-center gap-3 sm:flex-row">
-              <SignInButton>
+              <SignInButton mode="modal">
                 <Button size="lg">Get started free</Button>
               </SignInButton>
               <a href="#features" className="w-full sm:w-auto">
@@ -308,7 +308,7 @@ function PublicHome() {
             Get started in minutes and keep everyone on the same page.
           </p>
           <div className="mt-6 flex items-center justify-center gap-4">
-            <SignInButton>
+            <SignInButton mode="modal">
               <Button size="lg">Start now</Button>
             </SignInButton>
             <a href="#features">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,7 +33,7 @@ export function Header() {
 
       <div className="flex items-center">
         <SignedOut>
-          <SignInButton>
+          <SignInButton mode="modal">
             <Button variant={"link"}>Sign in</Button>
           </SignInButton>
         </SignedOut>

--- a/src/hooks/use-persist-user.tsx
+++ b/src/hooks/use-persist-user.tsx
@@ -1,5 +1,5 @@
 import { useConvexAuth } from "convex/react";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 
@@ -10,8 +10,35 @@ export type AuthState = {
   userId: Id<"users"> | null;
 };
 
+export type PersistUserAuthStatus =
+  | "checkingAuth"
+  | "signedOut"
+  | "checkingUser"
+  | "persistingUser"
+  | "ready"
+  | "error";
+
+export type PersistUserAuth = {
+  status: PersistUserAuthStatus;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  isSignedIn: boolean;
+  authState: AuthState;
+  error: Error | null;
+};
+
+function toError(error: unknown) {
+  return error instanceof Error
+    ? error
+    : new Error("Failed to persist authenticated user");
+}
+
 export function usePersistUserEffect() {
   const { isLoading: authIsLoading, isAuthenticated } = useConvexAuth();
+  const bootstrapPersistStartedRef = useRef(false);
+  const backgroundSyncStartedRef = useRef(false);
+  const [bootstrapPersistError, setBootstrapPersistError] =
+    useState<Error | null>(null);
 
   const { data: user, isLoading: userQueryIsLoading } = useQuery(
     convexQuery(
@@ -20,31 +47,86 @@ export function usePersistUserEffect() {
     ),
   );
 
-  const { mutate: storeUser, isPending: isStoringUser } = useMutation({
+  const { mutateAsync: persistUser } = useMutation({
     mutationFn: useConvexMutation(api.user.persist),
   });
 
   useEffect(() => {
-    // Don't do anything until we know if the user exists or not.
-    if (!isAuthenticated || userQueryIsLoading) {
+    if (!isAuthenticated) {
+      bootstrapPersistStartedRef.current = false;
+      backgroundSyncStartedRef.current = false;
       return;
     }
 
-    // This will run for new users (user is null) and existing users (user is not null).
-    // For existing users, it's a background sync that won't block the UI.
-    // For new users, the `isCreatingUser` flag will be used to block the UI.
-    storeUser({});
-  }, [isAuthenticated, storeUser, userQueryIsLoading]);
+    if (userQueryIsLoading) {
+      return;
+    }
 
-  const isCreatingUser = user === null && isStoringUser;
-  const isLoading = authIsLoading || userQueryIsLoading || isCreatingUser;
+    if (user) {
+      if (
+        bootstrapPersistStartedRef.current ||
+        backgroundSyncStartedRef.current
+      ) {
+        return;
+      }
+
+      backgroundSyncStartedRef.current = true;
+      void persistUser({}).catch(() => {
+        backgroundSyncStartedRef.current = false;
+      });
+      return;
+    }
+
+    if (bootstrapPersistError) {
+      return;
+    }
+
+    if (bootstrapPersistStartedRef.current) {
+      return;
+    }
+
+    bootstrapPersistStartedRef.current = true;
+    void persistUser({}).catch((error) => {
+      bootstrapPersistStartedRef.current = false;
+      setBootstrapPersistError(toError(error));
+    });
+  }, [
+    bootstrapPersistError,
+    isAuthenticated,
+    persistUser,
+    user,
+    userQueryIsLoading,
+  ]);
+
+  let status: PersistUserAuthStatus;
+
+  if (authIsLoading) {
+    status = "checkingAuth";
+  } else if (!isAuthenticated) {
+    status = "signedOut";
+  } else if (userQueryIsLoading) {
+    status = "checkingUser";
+  } else if (user) {
+    status = "ready";
+  } else if (bootstrapPersistError) {
+    status = "error";
+  } else {
+    status = "persistingUser";
+  }
+
+  const isLoading =
+    status === "checkingAuth" ||
+    status === "checkingUser" ||
+    status === "persistingUser";
 
   return {
+    status,
     isLoading,
-    // A user is considered fully authenticated and ready once they exist in the DB.
-    isAuthenticated: isAuthenticated && !!user,
+    isAuthenticated: status === "ready",
+    isSignedIn: isAuthenticated,
     authState: {
       userId: user?._id ?? null,
     },
-  };
+    error: bootstrapPersistError,
+  } satisfies PersistUserAuth;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from "react-dom/client";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 import { getClients } from "@/lib/queryClient";
-import { useConvexAuth } from "convex/react";
 import { Loader2 } from "lucide-react";
 import { ClerkProvider, useAuth } from "@clerk/clerk-react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
@@ -11,6 +10,7 @@ import { ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 
 import "@/styles/globals.css";
+import { usePersistUserEffect } from "@/hooks/use-persist-user";
 
 const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY ?? "";
 const clients = getClients();
@@ -42,11 +42,24 @@ function RootProviders({ children }: { children: ReactNode }) {
 }
 
 function App() {
-  const auth = useConvexAuth();
+  const auth = usePersistUserEffect();
   if (auth.isLoading) {
     return (
       <div className="relative container mx-auto flex grow flex-col items-center p-12">
         <Loader2 className="h-10 w-10 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (auth.status === "error") {
+    return (
+      <div className="relative container mx-auto flex grow flex-col items-center justify-center gap-2 p-12 text-center">
+        <p className="text-sm font-medium text-foreground">
+          We couldn&apos;t finish setting up your account.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Refresh and try signing in again.
+        </p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- replace the boolean auth gate with explicit bootstrap statuses for auth, user lookup, persistence, ready, and error states
- route public and authenticated redirects off auth status so first-time signed-in users are not redirected before persistence completes
- remove the nested authenticated layout persistor to avoid double loading gates that interfered with initial skeleton rendering
- switch sign-in entry points to Clerk modal mode for a smoother sign-in flow

## Testing
- `bun run check`