### PR TITLE
Configure app icons, robots rules, and Vercel caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ExpenseMate</title>
+    <link rel="icon" href="/icon.png" />
+    <link rel="apple-touch-icon" href="/apple-icon.png" />
   </head>
 
   <body>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /dashboard
+Disallow: /settings

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,32 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "redirects": [
+    { "source": "/favicon.ico", "destination": "/icon.png", "permanent": true }
+  ],
+  "rewrites": [
+    {
+      "source": "/:path((?!.*\\.(?:php|phtml|asp|aspx|jsp|cgi|pl|sh|sql|bak|old|env|ini|yml|yaml|xml|toml|log|zip|tar|gz)$).*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(icon.png|apple-icon.png|logo.webp)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate=604800"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add favicon and Apple touch icon links to the app shell.
- Add robots.txt rules blocking dashboard and settings from crawlers.
- Configure the favicon redirect, SPA rewrites, and static asset caching on Vercel.

## Testing
- Not run (configuration and metadata changes only).