### PR TITLE
Make adding expenses snappier

### DIFF
--- a/src/components/ExpenseCard.tsx
+++ b/src/components/ExpenseCard.tsx
@@ -77,7 +77,7 @@ export function ExpenseCardCompact({
   return (
     <div
       className={cn(
-        "relative overflow-hidden rounded-xl border bg-card shadow-sm transition-all duration-200 hover:shadow-md",
+        "relative overflow-hidden rounded-xl border bg-card shadow-sm transition-shadow duration-75 hover:shadow-md",
         className,
       )}
     >

--- a/src/components/ExpensesTabContent.tsx
+++ b/src/components/ExpensesTabContent.tsx
@@ -245,7 +245,7 @@ export function AddExpenseDialogButton({
       <DialogContent>
         <VisuallyHidden>
           <DialogHeader>
-            <DialogTitle>Add Expense</DialogTitle>´
+            <DialogTitle>Add Expense</DialogTitle>
           </DialogHeader>
         </VisuallyHidden>
 
@@ -336,7 +336,7 @@ function ExpenseDialogButton({
     <Button
       {...rest}
       className={cn(
-        "h-12 rounded-full shadow-lg transition-all duration-200 ease-out hover:shadow-xl",
+        "h-12 rounded-full shadow-lg transition-all duration-75 ease-out hover:shadow-xl",
         showText ? "w-36 px-4" : "w-12 px-0",
       )}
     >
@@ -344,7 +344,7 @@ function ExpenseDialogButton({
         <Plus className="h-6 w-6 shrink-0" />
         <span
           className={cn(
-            "overflow-hidden whitespace-nowrap transition-all duration-200 ease-in-out",
+            "overflow-hidden whitespace-nowrap transition-all duration-75 ease-in-out",
             showText
               ? "ml-2 max-w-[200px] opacity-100"
               : "ml-0 max-w-0 opacity-0",

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -62,7 +62,7 @@ function AccordionTrigger({
         {...props}
       >
         {children}
-        <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
+        <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-75" />
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   );
@@ -81,7 +81,7 @@ function AccordionContent({
     >
       <div
         className={cn(
-          "h-(--accordion-panel-height) overflow-hidden data-ending-style:h-0 data-starting-style:h-0",
+          "h-(--accordion-panel-height) overflow-hidden transition-[height] duration-75 data-ending-style:h-0 motion-reduce:transition-none",
           className,
         )}
       >

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -18,7 +18,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Backdrop
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 transition-opacity data-ending-style:opacity-0 data-starting-style:opacity-0",
+      "fixed inset-0 z-50 bg-black/80 transition-opacity duration-75 data-ending-style:opacity-0 motion-reduce:transition-none",
       className,
     )}
     {...props}
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Popup
       ref={ref}
       className={cn(
-        "fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg transition-[opacity,transform] duration-200 data-ending-style:translate-x-[-50%] data-ending-style:translate-y-[-48%] data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:translate-x-[-50%] data-starting-style:translate-y-[-48%] data-starting-style:scale-95 data-starting-style:opacity-0 sm:rounded-lg",
+        "fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg transition-opacity duration-75 data-ending-style:opacity-0 motion-reduce:transition-none sm:rounded-lg",
         className,
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Backdrop
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 transition-opacity data-ending-style:opacity-0 data-starting-style:opacity-0",
+      "fixed inset-0 z-50 bg-black/80 transition-opacity duration-75 data-ending-style:opacity-0 motion-reduce:transition-none",
       className,
     )}
     {...props}
@@ -38,11 +38,11 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Popup
       ref={ref}
       className={cn(
-        "fixed z-50 grid w-full gap-4 border bg-background shadow-lg transition-[opacity,transform] duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
+        "fixed z-50 grid w-full gap-4 border bg-background shadow-lg transition-opacity duration-75 data-ending-style:opacity-0 motion-reduce:transition-none",
         // Mobile: Full screen with scrolling
         "inset-0 h-full max-h-screen rounded-none p-4",
         // Desktop: Centered with max width and no scrolling
-        "sm:top-[50%] sm:left-[50%] sm:h-fit sm:max-h-[85vh] sm:w-full sm:max-w-lg sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:p-6 sm:data-ending-style:scale-95 sm:data-ending-style:translate-x-[-50%] sm:data-ending-style:translate-y-[-48%] sm:data-starting-style:scale-95 sm:data-starting-style:translate-x-[-50%] sm:data-starting-style:translate-y-[-48%]",
+        "sm:top-[50%] sm:left-[50%] sm:h-fit sm:max-h-[85vh] sm:w-full sm:max-w-lg sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:p-6",
         className,
       )}
       {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -71,7 +71,7 @@ const DropdownMenuSubContent = React.forwardRef<
         <DropdownMenuPrimitive.Popup
           ref={ref}
           className={cn(
-            "z-50 min-w-32 origin-(--transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg outline-none transition-[opacity,transform] data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 data-[side=bottom]:data-starting-style:-translate-y-2 data-[side=left]:data-starting-style:translate-x-2 data-[side=right]:data-starting-style:-translate-x-2 data-[side=top]:data-starting-style:translate-y-2",
+            "z-50 min-w-32 origin-(--transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg outline-none transition-opacity duration-75 data-ending-style:opacity-0 motion-reduce:transition-none",
             className,
           )}
           {...props}
@@ -115,7 +115,7 @@ const DropdownMenuContent = React.forwardRef<
         <DropdownMenuPrimitive.Popup
           ref={ref}
           className={cn(
-            "z-50 max-h-(--available-height) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none transition-[opacity,transform] data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0 data-[side=bottom]:data-starting-style:-translate-y-2 data-[side=left]:data-starting-style:translate-x-2 data-[side=right]:data-starting-style:-translate-x-2 data-[side=top]:data-starting-style:translate-y-2",
+            "z-50 max-h-(--available-height) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none transition-opacity duration-75 data-ending-style:opacity-0 motion-reduce:transition-none",
             className,
           )}
           {...props}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -63,6 +63,7 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  --default-transition-duration: 75ms;
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);


### PR DESCRIPTION
## Summary
- Pass current/other user IDs into the expense form and include the other user's id on shared expenses, so the form only fetches currencies instead of reloading connection data the page already has.
- Prefetch supported currencies on the connection route so the add/edit dialog does not wait on that query at open time.
- Drop Base UI enter animations on dialogs, alert dialogs, and dropdowns so overlays appear immediately, and cap remaining UI motion at 75ms.

## Test plan
- [ ] Open a connection page and click Add Expense; the modal should appear immediately with the form ready (You/Them options populated).
- [ ] Submit a new expense and confirm it still saves and closes the dialog.
- [ ] Open an existing expense to edit; You/Them, currencies, and save/delete still work.
- [ ] Close the add/edit dialogs and confirm they fade out quickly without feeling laggy.
- [ ] Open a dropdown/menu and an alert dialog (e.g. remove connection) and confirm they also appear immediately.