### PR TITLE
Restore invite flow and fix expense-list React issues

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "@convex-dev/react-query": "^0.1.0",
         "@tanstack/react-query": "5.101.4",
         "@tanstack/react-router": "1.170.27",
-        "@tanstack/react-virtual": "^3.14.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "convex": "^1.43.0",
@@ -46,7 +45,6 @@
         "prettier": "^3.9.6",
         "prettier-plugin-tailwindcss": "^0.8.1",
         "tailwindcss": "^4.3.3",
-        "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.67.0",
         "vite": "^8.2.1",
@@ -284,8 +282,6 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
-    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.9", "", { "dependencies": { "@tanstack/virtual-core": "3.17.7" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ=="],
-
     "@tanstack/router-core": ["@tanstack/router-core@1.171.22", "", { "dependencies": { "@tanstack/history": "1.162.1", "cookie-es": "^3.0.0", "seroval": "^1.6.2", "seroval-plugins": "^1.6.2" } }, "sha512-sitsuRkz4qpTjIAV97S5zFCoeGv0OFd6+VWg3ZcIlQbi5R4NIXfz6ogg51n5w6rvTwSODz/lKWb5dl5tvh2bQw=="],
 
     "@tanstack/router-generator": ["@tanstack/router-generator@1.167.28", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.22", "@tanstack/router-utils": "1.162.2", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^4.4.3" } }, "sha512-AxvzdqQoBxrA8hoO1fHYg4cAUVug/xLqQhsGbNG1PelU3RbYRYEtDim7+HbYQCOqJaEuvV8tCvrTPTnT69iIwg=="],
@@ -295,8 +291,6 @@
     "@tanstack/router-utils": ["@tanstack/router-utils@1.162.2", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
-
-    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.7", "", {}, "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA=="],
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 
@@ -611,8 +605,6 @@
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 

--- a/convex/connections.ts
+++ b/convex/connections.ts
@@ -19,10 +19,18 @@ export const getConnectionById = query({
     v.null(),
   ),
   handler: async (ctx, args) => {
+    const me = await getMeDocument(ctx);
     const connection = await ctx.db.get("user_connections", args.id);
 
     if (!connection) {
       return null;
+    }
+
+    if (
+      connection.inviterUserId !== me._id &&
+      connection.inviteeUserId !== me._id
+    ) {
+      throw new Error("Unauthorized to view this connection");
     }
 
     return {
@@ -163,16 +171,19 @@ export const deleteConnection = mutation({
       otherExpenseRows.map((row) => [row.expenseId, row]),
     );
 
-    for (const myRow of myExpenseRows) {
+    const sharedExpenseDeletes = myExpenseRows.flatMap((myRow) => {
       const otherRow = otherExpenseById.get(myRow.expenseId);
       if (!otherRow) {
-        continue;
+        return [];
       }
 
-      await ctx.db.delete("user_expenses", myRow._id);
-      await ctx.db.delete("user_expenses", otherRow._id);
-      await ctx.db.delete("expenses", myRow.expenseId);
-    }
+      return [
+        ctx.db.delete("user_expenses", myRow._id),
+        ctx.db.delete("user_expenses", otherRow._id),
+        ctx.db.delete("expenses", myRow.expenseId),
+      ];
+    });
+    await Promise.all(sharedExpenseDeletes);
 
     // Finally, delete the connection
     await ctx.db.delete("user_connections", args.connectionId);

--- a/convex/expenses.ts
+++ b/convex/expenses.ts
@@ -154,6 +154,10 @@ export const addExpense = mutation({
       me._id,
     );
 
+    if (args.paidBy !== me._id && args.paidBy !== otherUserId) {
+      throw new Error("Payer must be a participant in this connection");
+    }
+
     // Determine payer and non-payer
     const payerId = args.paidBy;
     const nonPayerId = payerId === me._id ? otherUserId : me._id;
@@ -260,6 +264,29 @@ export const updateExpense = mutation({
       throw new Error("Expense not found");
     }
 
+    const existingUserExpenses = await ctx.db
+      .query("user_expenses")
+      .withIndex("by_expense", (q) => q.eq("expenseId", id))
+      .collect();
+
+    const participantIds = [connection.inviterUserId, connection.inviteeUserId];
+    const expenseUserIds = new Set(
+      existingUserExpenses.map((userExpense) => userExpense.userId),
+    );
+
+    if (
+      existingUserExpenses.length !== 2 ||
+      !participantIds.every((participantId) =>
+        expenseUserIds.has(participantId),
+      )
+    ) {
+      throw new Error("Expense does not belong to this connection");
+    }
+
+    if (!participantIds.includes(args.paidBy)) {
+      throw new Error("Payer must be a participant in this connection");
+    }
+
     // Handle currency conversion for updates
     let finalTotalCost = args.totalCost ?? existingExpense.totalCost;
     let updateData: Omit<Doc<"expenses">, "_id" | "_creationTime"> = {
@@ -318,32 +345,23 @@ export const updateExpense = mutation({
       throw new Error("Failed to get updated expense");
     }
 
-    // Get existing user_expenses for this expense
-    const existingUserExpenses = await ctx.db
-      .query("user_expenses")
-      .withIndex("by_expense", (q) => q.eq("expenseId", id))
-      .collect();
-
     const payerId = args.paidBy;
     const totalCost = finalTotalCost; // Use the converted USD amount
     const splitEqually = args.splitEqually;
 
-    // Update existing user_expenses records
-    for (const userExpense of existingUserExpenses) {
-      if (userExpense.userId === payerId) {
-        // Update the payer's record
-        await ctx.db.patch("user_expenses", userExpense._id, {
-          amountPaid: totalCost,
-          amountOwed: splitEqually ? totalCost / 2 : 0,
-        });
-      } else {
-        // Update the non-payer's record
-        await ctx.db.patch("user_expenses", userExpense._id, {
-          amountPaid: 0,
-          amountOwed: splitEqually ? totalCost / 2 : totalCost,
-        });
-      }
-    }
+    await Promise.all(
+      existingUserExpenses.map((userExpense) =>
+        ctx.db.patch(
+          "user_expenses",
+          userExpense._id,
+          calculateExpenseAmounts(
+            totalCost,
+            splitEqually,
+            userExpense.userId === payerId,
+          ),
+        ),
+      ),
+    );
 
     return { expense: updatedExpense };
   },
@@ -372,11 +390,10 @@ export const deleteExpense = mutation({
       throw new Error("You are not a participant in this expense.");
     }
 
-    for (const ue of userExpenses) {
-      await ctx.db.delete("user_expenses", ue._id);
-    }
-
-    await ctx.db.delete("expenses", args.id);
+    await Promise.all([
+      ...userExpenses.map((ue) => ctx.db.delete("user_expenses", ue._id)),
+      ctx.db.delete("expenses", args.id),
+    ]);
 
     return { success: true };
   },

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -1,7 +1,35 @@
-import { internalMutation, mutation, query } from "./_generated/server";
+import {
+  internalMutation,
+  mutation,
+  query,
+  MutationCtx,
+} from "./_generated/server";
 import { v } from "convex/values";
 import { getMeDocument } from "./helpers";
 import { findConnectionBetweenUsers } from "./queries";
+
+function generateInvitationToken() {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+async function generateUniqueInvitationToken(ctx: MutationCtx) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const token = generateInvitationToken();
+    const existing = await ctx.db
+      .query("invitations")
+      .withIndex("by_token", (q) => q.eq("token", token))
+      .unique();
+    if (!existing) {
+      return token;
+    }
+  }
+
+  throw new Error("Failed to generate a unique invitation token");
+}
 
 // Get an invitation link for a user
 export const getInvitationLink = mutation({
@@ -16,8 +44,7 @@ export const getInvitationLink = mutation({
       throw new Error("Inviter not found");
     }
 
-    // Generate a unique token
-    const token = Math.random().toString(36).substring(2);
+    const token = await generateUniqueInvitationToken(ctx);
     const expirationTime = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours from now
 
     // Store the invitation in the database
@@ -50,15 +77,17 @@ export const expireAllInvitations = mutation({
 
     const now = Date.now();
     const epochIso = new Date(0).toISOString();
-    for (const invitation of invitations) {
-      if (new Date(invitation.expirationTime).getTime() <= now) {
-        continue;
-      }
-
-      await ctx.db.patch("invitations", invitation._id, {
-        expirationTime: epochIso,
-      });
-    }
+    await Promise.all(
+      invitations
+        .filter(
+          (invitation) => new Date(invitation.expirationTime).getTime() > now,
+        )
+        .map((invitation) =>
+          ctx.db.patch("invitations", invitation._id, {
+            expirationTime: epochIso,
+          }),
+        ),
+    );
 
     return null;
   },
@@ -211,11 +240,13 @@ export const deleteExpiredInvitations = internalMutation({
       )
       .collect();
 
-    for (const invitation of invitations) {
-      const expirationTime = new Date(invitation.expirationTime).getTime();
-      if (expirationTime < Date.now()) {
-        await ctx.db.delete("invitations", invitation._id);
-      }
-    }
+    const now = Date.now();
+    await Promise.all(
+      invitations
+        .filter(
+          (invitation) => new Date(invitation.expirationTime).getTime() < now,
+        )
+        .map((invitation) => ctx.db.delete("invitations", invitation._id)),
+    );
   },
 });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@convex-dev/react-query": "^0.1.0",
     "@tanstack/react-query": "5.101.4",
     "@tanstack/react-router": "1.170.27",
-    "@tanstack/react-virtual": "^3.14.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "^1.43.0",
@@ -59,7 +58,6 @@
     "prettier": "^3.9.6",
     "prettier-plugin-tailwindcss": "^0.8.1",
     "tailwindcss": "^4.3.3",
-    "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.67.0",
     "vite": "^8.2.1"

--- a/src/app/_authenticated/settings.tsx
+++ b/src/app/_authenticated/settings.tsx
@@ -205,18 +205,25 @@ function GenerateInvitationDialog() {
     try {
       const dataFromMutation = await getInvitationLink();
 
-      if (dataFromMutation) {
-        const invitationLink = dataFromMutation.invitationLink;
-        const { renderSVG } = await import("uqr");
-        const svg = renderSVG(`${window.location.host}${invitationLink}`);
-        setState({
-          status: "ready",
-          data: svg,
-          invitationLink: `${window.location.host}${invitationLink}`,
-        });
-      } else {
+      if (!dataFromMutation) {
         setState({ status: "idle", data: null, invitationLink: null });
+        toast({
+          title: "Error",
+          description:
+            "Could not generate an invitation link. Please try again.",
+          variant: "destructive",
+        });
+        return;
       }
+
+      const invitationLink = `${window.location.origin}${dataFromMutation.invitationLink}`;
+      const { renderSVG } = await import("uqr");
+      const svg = renderSVG(invitationLink);
+      setState({
+        status: "ready",
+        data: svg,
+        invitationLink,
+      });
     } catch (error) {
       setState({ status: "idle", data: null, invitationLink: null });
       toast({
@@ -388,6 +395,7 @@ function ConnectionActionsDropdown({
     api.connections.deleteConnection,
     {
       onSuccess: () => {
+        setDeleteDialogOpen(false);
         toast({
           title: "Connection Removed",
           description: `Connection with ${userName} has been removed.`,
@@ -412,7 +420,11 @@ function ConnectionActionsDropdown({
       <DropdownMenu>
         <DropdownMenuTrigger
           render={
-            <Button variant="ghost" size="sm">
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label={`Actions for ${userName}`}
+            >
               <MoreHorizontal className="h-4 w-4" />
             </Button>
           }

--- a/src/app/_public/index.tsx
+++ b/src/app/_public/index.tsx
@@ -6,7 +6,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -70,10 +70,14 @@ function PublicHome() {
               <SignInButton mode="modal">
                 <Button size="lg">Get started free</Button>
               </SignInButton>
-              <a href="#features" className="w-full sm:w-auto">
-                <Button variant="outline" size="lg" className="w-full">
-                  Learn more
-                </Button>
+              <a
+                href="#features"
+                className={
+                  buttonVariants({ variant: "outline", size: "lg" }) +
+                  " w-full sm:w-auto"
+                }
+              >
+                Explore features
               </a>
             </div>
 
@@ -311,10 +315,11 @@ function PublicHome() {
             <SignInButton mode="modal">
               <Button size="lg">Start now</Button>
             </SignInButton>
-            <a href="#features">
-              <Button variant="outline" size="lg">
-                Explore features
-              </Button>
+            <a
+              href="#features"
+              className={buttonVariants({ variant: "outline", size: "lg" })}
+            >
+              Explore features
             </a>
           </div>
         </section>

--- a/src/app/invite/$token.tsx
+++ b/src/app/invite/$token.tsx
@@ -1,0 +1,101 @@
+import { convexQuery } from "@convex-dev/react-query";
+import { api } from "@convex/_generated/api";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { SignInButton } from "@clerk/clerk-react";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+
+import { PublicLayout } from "@/components/PublicLayout";
+import { Button } from "@/components/ui/button";
+import { useConvexMutation } from "@/hooks/use-convex-mutation";
+
+export const Route = createFileRoute("/invite/$token")({
+  component: InvitePage,
+});
+
+function InvitePage() {
+  const { token } = Route.useParams();
+  const { auth } = Route.useRouteContext();
+
+  return (
+    <PublicLayout>
+      <main className="mx-auto flex w-full max-w-lg grow flex-col items-center justify-center p-6 text-center">
+        <h1 className="mb-4 text-3xl font-bold">Invitation</h1>
+        {auth.isSignedIn ? (
+          <InvitationContent token={token} />
+        ) : (
+          <div className="space-y-4">
+            <p className="text-muted-foreground">
+              Sign in to accept this invitation and start sharing expenses.
+            </p>
+            <SignInButton mode="modal">
+              <Button size="lg">Sign in to continue</Button>
+            </SignInButton>
+          </div>
+        )}
+      </main>
+    </PublicLayout>
+  );
+}
+
+function InvitationContent({ token }: { token: string }) {
+  const navigate = useNavigate();
+  const invitationQuery = useQuery(
+    convexQuery(api.invitations.getInvitation, { token }),
+  );
+  const {
+    mutate: acceptInvitation,
+    isPending,
+    error,
+  } = useConvexMutation(api.invitations.acceptInvitation, {
+    onSuccess: () => {
+      void navigate({ to: "/dashboard" });
+    },
+  });
+
+  if (invitationQuery.isPending) {
+    return <Loader2 className="h-8 w-8 animate-spin text-primary" />;
+  }
+
+  if (invitationQuery.isError || !invitationQuery.data) {
+    return (
+      <div className="space-y-4">
+        <p className="text-muted-foreground">
+          This invitation doesn&apos;t exist, has expired, or can&apos;t be
+          accepted with this account.
+        </p>
+        <Button nativeButton={false} render={<Link to="/dashboard" />}>
+          Go to dashboard
+        </Button>
+      </div>
+    );
+  }
+
+  const { invitation, inviter } = invitationQuery.data;
+
+  if (invitation.isUsed) {
+    return (
+      <div className="space-y-4">
+        <p className="text-muted-foreground">
+          This invitation was already accepted.
+        </p>
+        <Button nativeButton={false} render={<Link to="/dashboard" />}>
+          Go to dashboard
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p>
+        <span className="font-medium">{inviter.name}</span> is inviting you to
+        share expenses.
+      </p>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <Button onClick={() => acceptInvitation({ token })} disabled={isPending}>
+        {isPending ? "Processing..." : "Accept Invitation"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/AddExpenseForm.tsx
+++ b/src/components/AddExpenseForm.tsx
@@ -47,7 +47,7 @@ export function AddExpenseForm({
   currentUserId: Id<"users">;
   otherUserId: Id<"users">;
 }) {
-  const [isManualSelection, setIsManualSelection] = useState(false);
+  const isManualSelection = useRef(false);
   const [selectedCurrency, setSelectedCurrency] = useState(
     initialValues.currency,
   );
@@ -70,7 +70,9 @@ export function AddExpenseForm({
     if (isNewExpense && categorySelectRef.current && newName.length >= 3) {
       const currentCategory = categorySelectRef.current.value;
       const shouldSuggest =
-        !isManualSelection || currentCategory === "None" || !currentCategory;
+        !isManualSelection.current ||
+        currentCategory === "None" ||
+        !currentCategory;
 
       if (shouldSuggest) {
         const suggestedCategory = suggestCategory(newName);
@@ -84,9 +86,9 @@ export function AddExpenseForm({
   const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedCategory = e.target.value;
     if (selectedCategory === "None" || !selectedCategory) {
-      setIsManualSelection(false);
+      isManualSelection.current = false;
     } else {
-      setIsManualSelection(true);
+      isManualSelection.current = true;
     }
   };
 

--- a/src/components/ConnectedUsersList.tsx
+++ b/src/components/ConnectedUsersList.tsx
@@ -66,7 +66,7 @@ export const ConnectionListItem = ({
       <Link
         to="/dashboard/connection/$connectionId"
         params={{ connectionId }}
-        className="block transform rounded-lg border border-border bg-card p-4 shadow-sm transition-all hover:scale-[1.01] hover:shadow-md"
+        className="block transform rounded-lg border border-border bg-card p-4 shadow-sm transition-[transform,box-shadow] hover:scale-[1.01] hover:shadow-md motion-reduce:transition-none motion-reduce:hover:scale-100"
       >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">

--- a/src/components/CustomUserButton.tsx
+++ b/src/components/CustomUserButton.tsx
@@ -33,7 +33,11 @@ export function CustomUserButton() {
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
-          <Button variant="ghost" className="relative h-8 w-8 rounded-full">
+          <Button
+            variant="ghost"
+            className="relative size-11 rounded-full"
+            aria-label="Account menu"
+          >
             <Avatar className="h-8 w-8">
               <AvatarImage src={user.imageUrl} alt={user.fullName || "User"} />
               <AvatarFallback>

--- a/src/components/DashboardContent.tsx
+++ b/src/components/DashboardContent.tsx
@@ -4,10 +4,10 @@ import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@convex/_generated/api";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import { Plus, Users } from "lucide-react";
 import { Link } from "@tanstack/react-router";
-import { formatDollars } from "@/lib/utils";
+import { formatDollars, cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export function DashboardSummary() {
@@ -59,10 +59,14 @@ export function DashboardHeader() {
           Overview of your connections and recent activity
         </p>
       </div>
-      <Link to="/settings">
-        <Button size="sm" className="gap-2">
-          <Plus className="h-4 w-4" /> Invite a friend
-        </Button>
+      <Link
+        to="/settings"
+        className={cn(
+          buttonVariants({ variant: "default", size: "sm" }),
+          "gap-2",
+        )}
+      >
+        <Plus className="h-4 w-4" /> Invite a friend
       </Link>
     </div>
   );

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,6 @@
 import React, { Component } from "react";
+import { Link } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
 
 export class ErrorBoundary extends Component<{
   children: React.ReactNode;
@@ -22,4 +24,18 @@ export class ErrorBoundary extends Component<{
 
     return this.props.children;
   }
+}
+
+export function DefaultRouteError({ error }: { error: Error }) {
+  return (
+    <div className="mx-auto flex max-w-md grow flex-col items-center justify-center gap-3 p-8 text-center">
+      <p className="text-sm font-medium text-foreground">
+        Something went wrong.
+      </p>
+      <p className="text-sm text-muted-foreground">{error.message}</p>
+      <Button nativeButton={false} render={<Link to="/dashboard" />}>
+        Back to dashboard
+      </Button>
+    </div>
+  );
 }

--- a/src/components/ExpenseCard.tsx
+++ b/src/components/ExpenseCard.tsx
@@ -98,7 +98,7 @@ export function ExpenseCardCompact({
                 <Calendar className="mr-1 h-3 w-3" />
                 {date}
                 {updatedAt && (
-                  <span className="ml-2 text-[10px] text-muted-foreground/70 italic">
+                  <span className="ml-2 text-xs text-muted-foreground italic">
                     Edited {new Date(updatedAt).toLocaleDateString()}
                   </span>
                 )}

--- a/src/components/ExpensesTabContent.tsx
+++ b/src/components/ExpensesTabContent.tsx
@@ -21,6 +21,7 @@ import { cn } from "@/lib/utils";
 import { Id } from "@convex/_generated/dataModel";
 import { api } from "@convex/_generated/api";
 import { useConvexMutation } from "@/hooks/use-convex-mutation";
+import { useToast } from "@/hooks/use-toast";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { convexQuery } from "@convex-dev/react-query";
 import { LoadingFormComponent } from "@/components/LoadingComponent";
@@ -66,10 +67,22 @@ export function ConnectionExpenseList({
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const isSlash = e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey;
-      if (isSlash) {
-        e.preventDefault();
-        searchInputRef.current?.focus();
+      if (!isSlash) {
+        return;
       }
+
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest(
+          "input, textarea, select, [contenteditable='true'], [role='dialog']",
+        )
+      ) {
+        return;
+      }
+
+      e.preventDefault();
+      searchInputRef.current?.focus();
     };
 
     window.addEventListener("keydown", onKey);
@@ -115,6 +128,7 @@ export function ConnectionExpenseList({
             name="search"
             value={searchTerm}
             placeholder="Search..."
+            aria-label="Search expenses"
             onChange={(e) => setSearchTerm(e.target.value)}
           />
           <kbd className="pointer-events-none absolute top-1/2 right-2 hidden -translate-y-1/2 rounded border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground md:block">
@@ -135,7 +149,7 @@ export function ConnectionExpenseList({
                 aria-pressed={selected}
                 onClick={() => setPayerFilter(option.value)}
                 className={cn(
-                  "h-8 rounded-sm px-3 shadow-none hover:bg-background/80 hover:text-foreground",
+                  "h-11 min-h-11 rounded-sm px-3 shadow-none hover:bg-background/80 hover:text-foreground",
                   selected && "bg-background text-foreground shadow-sm",
                 )}
               >
@@ -186,7 +200,10 @@ export function ConnectionExpenseList({
       </div>
 
       {searchItemsResponse.length === 0 && (
-        <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+        <div
+          role="status"
+          className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground"
+        >
           No expenses match this view.
         </div>
       )}
@@ -207,9 +224,17 @@ export function AddExpenseDialogButton({
 }) {
   const [open, setOpen] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
+  const { toast } = useToast();
   const addExpenseMutation = useConvexMutation(api.expenses.addExpense, {
     onSuccess: () => {
       setOpen(false);
+    },
+    onError: (message) => {
+      toast({
+        title: "Couldn't add expense",
+        description: message,
+        variant: "destructive",
+      });
     },
   });
 
@@ -275,7 +300,7 @@ export function AddExpenseDialogButton({
               variant="default"
               className="w-full sm:w-auto"
             >
-              {addExpenseMutation.isPending ? "Submitting..." : "Submit"}
+              {addExpenseMutation.isPending ? "Submitting..." : "Add expense"}
             </Button>
           </div>
         </Suspense>
@@ -324,11 +349,11 @@ function ExpenseDialogButton({
   variant,
   ...rest
 }: React.ComponentProps<"button"> & { variant: "desktop" | "mobile" }) {
-  const { scrollDirection } = useScrollDirection();
+  const { scrollDirection, isAtTop } = useScrollDirection();
   const showText =
     scrollDirection === "IDLE" ||
     scrollDirection === "UP" ||
-    (scrollDirection === "DOWN" && window.scrollY === 0);
+    (scrollDirection === "DOWN" && isAtTop);
 
   return variant === "desktop" ? (
     <Button {...rest}>Add Expense</Button>
@@ -336,7 +361,7 @@ function ExpenseDialogButton({
     <Button
       {...rest}
       className={cn(
-        "h-12 rounded-full shadow-lg transition-all duration-75 ease-out hover:shadow-xl",
+        "h-12 rounded-full shadow-lg transition-[width,padding,box-shadow] duration-75 ease-out hover:shadow-xl motion-reduce:transition-none",
         showText ? "w-36 px-4" : "w-12 px-0",
       )}
     >
@@ -344,7 +369,7 @@ function ExpenseDialogButton({
         <Plus className="h-6 w-6 shrink-0" />
         <span
           className={cn(
-            "overflow-hidden whitespace-nowrap transition-all duration-75 ease-in-out",
+            "overflow-hidden whitespace-nowrap transition-[max-width,margin,opacity] duration-75 ease-in-out motion-reduce:transition-none",
             showText
               ? "ml-2 max-w-[200px] opacity-100"
               : "ml-0 max-w-0 opacity-0",
@@ -417,23 +442,7 @@ function getWhoPaidExpenseDetails(
   };
 }
 
-function EditExpenseDialogButton({
-  currentUserId,
-  otherUserId,
-  connectionId,
-  id,
-  name,
-  date,
-  updatedAt,
-  category,
-  totalCost,
-  currency,
-  originalCurrency,
-  originalTotalCost,
-  balance,
-  paidBy,
-  splitEqually,
-}: {
+type EditExpenseDialogButtonProps = {
   currentUserId: Id<"users">;
   otherUserId: Id<"users">;
   connectionId: Id<"user_connections">;
@@ -449,14 +458,80 @@ function EditExpenseDialogButton({
   balance: number;
   paidBy: Id<"users">;
   splitEqually: boolean;
-}) {
+};
+
+function EditExpenseDialogButton(props: EditExpenseDialogButtonProps) {
   const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="w-full text-left"
+        onClick={() => setOpen(true)}
+      >
+        <ExpenseItem
+          name={props.name}
+          date={props.date}
+          updatedAt={props.updatedAt}
+          category={props.category}
+          currentUserId={props.currentUserId}
+          paidBy={props.paidBy}
+          splitEqually={props.splitEqually}
+          totalCost={props.totalCost}
+          originalCurrency={props.originalCurrency}
+          originalTotalCost={props.originalTotalCost}
+          balance={props.balance}
+        />
+      </button>
+      {open ? (
+        <EditExpenseDialog {...props} open={open} onOpenChange={setOpen} />
+      ) : null}
+    </>
+  );
+}
+
+function EditExpenseDialog({
+  currentUserId,
+  otherUserId,
+  connectionId,
+  id,
+  name,
+  category,
+  totalCost,
+  currency,
+  originalCurrency,
+  originalTotalCost,
+  paidBy,
+  splitEqually,
+  open,
+  onOpenChange,
+}: EditExpenseDialogButtonProps & {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { toast } = useToast();
   const formRef = useRef<HTMLFormElement>(null);
+  const formId = `edit-expense-form-${id}`;
   const updateExpenseMutation = useConvexMutation(api.expenses.updateExpense, {
-    onSuccess: () => setOpen(false),
+    onSuccess: () => onOpenChange(false),
+    onError: (message) => {
+      toast({
+        title: "Couldn't save expense",
+        description: message,
+        variant: "destructive",
+      });
+    },
   });
   const deleteExpenseMutation = useConvexMutation(api.expenses.deleteExpense, {
-    onSuccess: () => setOpen(false),
+    onSuccess: () => onOpenChange(false),
+    onError: (message) => {
+      toast({
+        title: "Couldn't delete expense",
+        description: message,
+        variant: "destructive",
+      });
+    },
   });
 
   const handleDelete = () => {
@@ -495,28 +570,7 @@ function EditExpenseDialogButton({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger
-        nativeButton={false}
-        render={
-          <div>
-            <ExpenseItem
-              name={name}
-              date={date}
-              updatedAt={updatedAt}
-              category={category}
-              currentUserId={currentUserId}
-              paidBy={paidBy}
-              splitEqually={splitEqually}
-              totalCost={totalCost}
-              originalCurrency={originalCurrency}
-              originalTotalCost={originalTotalCost}
-              balance={balance}
-            />
-          </div>
-        }
-      />
-
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <VisuallyHidden>
           <DialogHeader>
@@ -526,7 +580,7 @@ function EditExpenseDialogButton({
 
         <Suspense fallback={<LoadingFormComponent />}>
           <AddExpenseForm
-            id="edit-expense-form"
+            id={formId}
             ref={formRef}
             initialValues={{
               name: name,
@@ -566,7 +620,7 @@ function EditExpenseDialogButton({
             </Button>
             <Button
               type="submit"
-              form="edit-expense-form"
+              form={formId}
               disabled={actionIsInProgress}
               className="w-full sm:w-auto"
             >

--- a/src/components/NumberInput.tsx
+++ b/src/components/NumberInput.tsx
@@ -125,14 +125,14 @@ export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
     return (
       <Input
         type="text"
-        inputMode={inputMode || mode}
-        pattern={pattern || inputPattern}
         autoComplete="off"
         ref={ref}
-        value={value}
+        {...props}
+        inputMode={inputMode || mode}
+        pattern={pattern || inputPattern}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
-        {...props}
+        {...(value !== undefined ? { value } : {})}
       />
     );
   },

--- a/src/hooks/use-convex-mutation.ts
+++ b/src/hooks/use-convex-mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "convex/react";
 import { FunctionReference, OptionalRestArgs } from "convex/server";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 type UseConvexMutationOptions<
   Mutation extends FunctionReference<"mutation", "public">,
@@ -24,6 +24,7 @@ export const useConvexMutation = <
   const [isPending, setIsPending] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const pendingCountRef = useRef(0);
 
   const mutationFn = useMutation(mutation);
 
@@ -32,6 +33,7 @@ export const useConvexMutation = <
       ? []
       : [Mutation["_args"]]
   ): Promise<Mutation["_returnType"] | null> => {
+    pendingCountRef.current += 1;
     setIsPending(true);
     setIsSuccess(false);
     setError(null);
@@ -40,19 +42,23 @@ export const useConvexMutation = <
       const result = await mutationFn(
         ...(args as OptionalRestArgs<Mutation["_args"]>),
       );
+      pendingCountRef.current -= 1;
+      if (pendingCountRef.current === 0) {
+        setIsPending(false);
+      }
       setIsSuccess(true);
       options?.onSuccess?.(result);
       return result;
     } catch (err) {
+      pendingCountRef.current -= 1;
+      if (pendingCountRef.current === 0) {
+        setIsPending(false);
+      }
       const errorMessage =
         err instanceof Error ? err.message : "An unknown error occurred";
       setError(errorMessage);
       options?.onError?.(errorMessage);
-      // We return null on error to provide a consistent return type.
-      // The error state should be checked to handle failures.
       return null;
-    } finally {
-      setIsPending(false);
     }
   };
 

--- a/src/hooks/use-scroll-direction.ts
+++ b/src/hooks/use-scroll-direction.ts
@@ -1,35 +1,34 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export type ScrollDirection = "UP" | "DOWN" | "IDLE";
 
-export function useScrollDirection(): { scrollDirection: ScrollDirection } {
+export function useScrollDirection(): {
+  scrollDirection: ScrollDirection;
+  isAtTop: boolean;
+} {
   const [scrollDirection, setScrollDirection] =
     useState<ScrollDirection>("IDLE");
-  const [lastScrollY, setLastScrollY] = useState(0);
+  const [isAtTop, setIsAtTop] = useState(true);
+  const lastScrollYRef = useRef(0);
 
   useEffect(() => {
     const handleScroll = () => {
       const currentScrollY = window.scrollY;
 
-      // Skip if we're at the same position
-      if (currentScrollY === lastScrollY) return;
-
-      // Determine scroll direction
-      if (currentScrollY > lastScrollY) {
-        setScrollDirection("DOWN");
-      } else {
-        setScrollDirection("UP");
+      if (currentScrollY === lastScrollYRef.current) {
+        return;
       }
 
-      setLastScrollY(currentScrollY);
+      setScrollDirection(
+        currentScrollY > lastScrollYRef.current ? "DOWN" : "UP",
+      );
+      setIsAtTop(currentScrollY === 0);
+      lastScrollYRef.current = currentScrollY;
     };
 
-    // Add scroll event listener
     window.addEventListener("scroll", handleScroll, { passive: true });
-
-    // Cleanup
     return () => window.removeEventListener("scroll", handleScroll);
-  }, [lastScrollY]);
+  }, []);
 
-  return { scrollDirection };
+  return { scrollDirection, isAtTop };
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 
 import "@/styles/globals.css";
 import { usePersistUserEffect } from "@/hooks/use-persist-user";
+import { DefaultRouteError } from "@/components/ErrorBoundary";
 
 const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY ?? "";
 const clients = getClients();
@@ -18,6 +19,11 @@ const router = createRouter({
   routeTree,
   context: { auth: undefined!, clients },
   defaultPreload: "intent",
+  defaultErrorComponent: ({ error }) => (
+    <DefaultRouteError
+      error={error instanceof Error ? error : new Error("Something went wrong")}
+    />
+  ),
 });
 
 declare module "@tanstack/react-router" {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './app/__root'
 import { Route as AuthenticatedRouteRouteImport } from './app/_authenticated/route'
 import { Route as PublicIndexRouteImport } from './app/_public/index'
+import { Route as InviteTokenRouteImport } from './app/invite/$token'
 import { Route as AuthenticatedSettingsRouteImport } from './app/_authenticated/settings'
 import { Route as AuthenticatedDashboardRouteRouteImport } from './app/_authenticated/dashboard/route'
 import { Route as AuthenticatedDashboardIndexRouteImport } from './app/_authenticated/dashboard/index'
@@ -23,6 +24,11 @@ const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
 const PublicIndexRoute = PublicIndexRouteImport.update({
   id: '/_public/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const InviteTokenRoute = InviteTokenRouteImport.update({
+  id: '/invite/$token',
+  path: '/invite/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedSettingsRoute = AuthenticatedSettingsRouteImport.update({
@@ -53,12 +59,14 @@ export interface FileRoutesByFullPath {
   '/': typeof PublicIndexRoute
   '/dashboard': typeof AuthenticatedDashboardRouteRouteWithChildren
   '/settings': typeof AuthenticatedSettingsRoute
+  '/invite/$token': typeof InviteTokenRoute
   '/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/dashboard/connection/$connectionId': typeof AuthenticatedDashboardConnectionConnectionIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof PublicIndexRoute
   '/settings': typeof AuthenticatedSettingsRoute
+  '/invite/$token': typeof InviteTokenRoute
   '/dashboard': typeof AuthenticatedDashboardIndexRoute
   '/dashboard/connection/$connectionId': typeof AuthenticatedDashboardConnectionConnectionIdRoute
 }
@@ -67,6 +75,7 @@ export interface FileRoutesById {
   '/_authenticated': typeof AuthenticatedRouteRouteWithChildren
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRouteRouteWithChildren
   '/_authenticated/settings': typeof AuthenticatedSettingsRoute
+  '/invite/$token': typeof InviteTokenRoute
   '/_public/': typeof PublicIndexRoute
   '/_authenticated/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/_authenticated/dashboard/connection/$connectionId': typeof AuthenticatedDashboardConnectionConnectionIdRoute
@@ -77,15 +86,22 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard'
     | '/settings'
+    | '/invite/$token'
     | '/dashboard/'
     | '/dashboard/connection/$connectionId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/settings' | '/dashboard' | '/dashboard/connection/$connectionId'
+  to:
+    | '/'
+    | '/settings'
+    | '/invite/$token'
+    | '/dashboard'
+    | '/dashboard/connection/$connectionId'
   id:
     | '__root__'
     | '/_authenticated'
     | '/_authenticated/dashboard'
     | '/_authenticated/settings'
+    | '/invite/$token'
     | '/_public/'
     | '/_authenticated/dashboard/'
     | '/_authenticated/dashboard/connection/$connectionId'
@@ -93,6 +109,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   AuthenticatedRouteRoute: typeof AuthenticatedRouteRouteWithChildren
+  InviteTokenRoute: typeof InviteTokenRoute
   PublicIndexRoute: typeof PublicIndexRoute
 }
 
@@ -110,6 +127,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof PublicIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/invite/$token': {
+      id: '/invite/$token'
+      path: '/invite/$token'
+      fullPath: '/invite/$token'
+      preLoaderRoute: typeof InviteTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated/settings': {
@@ -176,6 +200,7 @@ const AuthenticatedRouteRouteWithChildren =
 
 const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRouteRoute: AuthenticatedRouteRouteWithChildren,
+  InviteTokenRoute: InviteTokenRoute,
   PublicIndexRoute: PublicIndexRoute,
 }
 export const routeTree = rootRouteImport


### PR DESCRIPTION
## Summary
- Restores a simple `/invite/$token` accept page (from the old TanStack/Next invite UI) so generated QR codes and links work again, and mints tokens with `crypto.getRandomValues` instead of `Math.random`.
- Tightens Convex authorization: `updateExpense` must belong to the supplied connection, `addExpense` `paidBy` must be a participant, and `getConnectionById` requires membership.
- Speeds up the connection expense list: scroll direction uses a ref instead of rebinding on every pixel, edit dialogs/mutation hooks mount only when opened, `try/finally` is removed so React Compiler can optimize the mutation hook, and connection deletes run in parallel.
- Surfaces mutation errors on add/edit/delete, labels search and icon-only controls, stops `/` from stealing keystrokes in forms, and uses absolute invitation URLs.

## Test plan
- [ ] Generate an invitation QR/link in Settings; confirm the copied URL includes `https://` (or the current origin) and `/invite/<token>`.
- [ ] Open the link while signed out: sign-in CTA stays on `/invite/...`. After sign-in, accept and land on the dashboard with a new connection.
- [ ] Open your own invite link and confirm it does not offer accept.
- [ ] On a connection page, type `/` in the add-expense name field and confirm it inserts `/` instead of jumping to search. `/` outside inputs still focuses search.
- [ ] Add/edit/delete an expense; force a failure (offline or invalid data) and confirm a toast/error appears instead of a silent no-op.
- [ ] Scroll the connection list on mobile: FAB collapses without jank; opening one expense does not require hooks on every card.
- [ ] Dashboard “Invite a friend” is a single link (one tab stop), and the account menu has an accessible name.